### PR TITLE
Use the socket shutdown() workaround on Python 2

### DIFF
--- a/etcd3gw/watch.py
+++ b/etcd3gw/watch.py
@@ -11,7 +11,6 @@
 #    under the License.
 
 import json
-import six
 import socket
 
 from etcd3gw.utils import _decode
@@ -65,14 +64,11 @@ class Watcher(object):
 
     def stop(self):
         try:
-            if six.PY2:
-                self._response.raw._fp.close()
-            else:
-                s = socket.fromfd(self._response.raw._fp.fileno(),
-                                  socket.AF_INET,
-                                  socket.SOCK_STREAM)
-                s.shutdown(socket.SHUT_RDWR)
-                s.close()
+            s = socket.fromfd(self._response.raw._fp.fileno(),
+                              socket.AF_INET,
+                              socket.SOCK_STREAM)
+            s.shutdown(socket.SHUT_RDWR)
+            s.close()
         except Exception:
             pass
         self._response.connection.close()


### PR DESCRIPTION
The previous technique used to try to force-close the watch socket didn't work on (at least) Python 2.7.12 but the old Python 3.x workaround seems to work fine on Python 2.7 as well. Use that.

Fixes #15