### PR TITLE
Fix for python 3

### DIFF
--- a/etcd3gw/lock.py
+++ b/etcd3gw/lock.py
@@ -10,6 +10,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import six
 import uuid
 
 from etcd3gw.utils import _encode
@@ -102,7 +103,7 @@ class Lock(object):
     def is_acquired(self):
         """Check if the lock is acquired"""
         values = self.client.get(self.key)
-        return self._uuid in values
+        return six.b(self._uuid) in values
 
     def __enter__(self):
         """Use the lock as a contextmanager"""

--- a/etcd3gw/tests/test_etcd3gw.py
+++ b/etcd3gw/tests/test_etcd3gw.py
@@ -17,6 +17,7 @@ test_etcd3-gateway
 Tests for `etcd3gw` module.
 """
 
+import six
 import threading
 import time
 import uuid
@@ -66,9 +67,9 @@ class TestEtcd3Gateway(base.TestCase):
         self.assertTrue(self.client.put('foo1', 2001))
         self.assertTrue(self.client.put('foo2', 'bar2'.encode("utf-8")))
 
-        self.assertEqual(['bar0'], self.client.get('foo0'))
-        self.assertEqual(['2001'], self.client.get('foo1'))
-        self.assertEqual(['bar2'], self.client.get('foo2'))
+        self.assertEqual([six.b('bar0')], self.client.get('foo0'))
+        self.assertEqual([six.b('2001')], self.client.get('foo1'))
+        self.assertEqual([six.b('bar2')], self.client.get('foo2'))
 
         self.assertEqual(True, self.client.delete('foo0'))
         self.assertEqual([], self.client.get('foo0'))
@@ -85,8 +86,8 @@ class TestEtcd3Gateway(base.TestCase):
         values = list(self.client.get_prefix('/doot1/range'))
         assert len(values) == 20
         for value, metadata in values:
-            self.assertEqual('i am a range', value)
-            self.assertTrue(metadata['key'].startswith('/doot1/range'))
+            self.assertEqual(six.b('i am a range'), value)
+            self.assertTrue(metadata['key'].startswith(six.b('/doot1/range')))
 
         self.assertEqual(True, self.client.delete_prefix('/doot1/range'))
         values = list(self.client.get_prefix('/doot1/range'))
@@ -104,19 +105,19 @@ class TestEtcd3Gateway(base.TestCase):
         for k, v in zip(initial_keys, initial_values):
             self.client.put('/doot2/{}'.format(k), v)
 
-        keys = ''
+        keys = six.b('')
         for value, meta in self.client.get_prefix(
                 '/doot2', sort_order='ascend'):
             keys += remove_prefix(meta['key'], '/doot2/')
 
-        assert keys == initial_keys
+        assert keys == six.b(initial_keys)
 
-        reverse_keys = ''
+        reverse_keys = six.b('')
         for value, meta in self.client.get_prefix(
                 '/doot2', sort_order='descend'):
             reverse_keys += remove_prefix(meta['key'], '/doot2/')
 
-        assert reverse_keys == ''.join(reversed(initial_keys))
+        assert reverse_keys == six.b(''.join(reversed(initial_keys)))
 
     @unittest.skipUnless(
         _is_etcd3_running(), "etcd3 is not available")
@@ -131,19 +132,19 @@ class TestEtcd3Gateway(base.TestCase):
         for k, v in zip(initial_keys, initial_values):
             self.client.put('/doot2/{}'.format(k), v)
 
-        keys = ''
+        keys = six.b('')
         for value, meta in self.client.get_prefix(
                 '/doot2', sort_order='ascend', sort_target='key'):
             keys += remove_prefix(meta['key'], '/doot2/')
 
-        assert keys == initial_keys_ordered
+        assert keys == six.b(initial_keys_ordered)
 
-        reverse_keys = ''
+        reverse_keys = six.b('')
         for value, meta in self.client.get_prefix(
                 '/doot2', sort_order='descend', sort_target='key'):
             reverse_keys += remove_prefix(meta['key'], '/doot2/')
 
-        assert reverse_keys == ''.join(reversed(initial_keys_ordered))
+        assert reverse_keys == six.b(''.join(reversed(initial_keys_ordered)))
 
     @unittest.skipUnless(
         _is_etcd3_running(), "etcd3 is not available")
@@ -157,19 +158,19 @@ class TestEtcd3Gateway(base.TestCase):
         for k, v in zip(initial_keys, initial_values):
             self.client.put('/expsortmod/{}'.format(k), v)
 
-        keys = ''
+        keys = six.b('')
         for value, meta in self.client.get_prefix(
                 '/expsortmod', sort_order='ascend', sort_target='mod'):
             keys += remove_prefix(meta['key'], '/expsortmod/')
 
-        assert keys == initial_keys
+        assert keys == six.b(initial_keys)
 
-        reverse_keys = ''
+        reverse_keys = six.b('')
         for value, meta in self.client.get_prefix(
                 '/expsortmod', sort_order='descend', sort_target='mod'):
             reverse_keys += remove_prefix(meta['key'], '/expsortmod/')
 
-        assert reverse_keys == ''.join(reversed(initial_keys))
+        assert reverse_keys == six.b(''.join(reversed(initial_keys)))
 
     @unittest.skipUnless(
         _is_etcd3_running(), "etcd3 is not available")
@@ -178,7 +179,7 @@ class TestEtcd3Gateway(base.TestCase):
         self.client.put(key, 'toot')
         status = self.client.replace(key, 'toot', 'doot')
         v = self.client.get(key)
-        self.assertEqual(['doot'], v)
+        self.assertEqual([six.b('doot')], v)
         self.assertTrue(status)
 
     @unittest.skipUnless(
@@ -188,7 +189,7 @@ class TestEtcd3Gateway(base.TestCase):
         self.client.put(key, 'boot')
         status = self.client.replace(key, 'toot', 'doot')
         v = self.client.get(key)
-        self.assertEqual(['boot'], v)
+        self.assertEqual([six.b('boot')], v)
         self.assertFalse(status)
 
     @unittest.skipUnless(
@@ -219,11 +220,11 @@ class TestEtcd3Gateway(base.TestCase):
 
         keys = lease.keys()
         self.assertEqual(2, len(keys))
-        self.assertIn('foo12', keys)
-        self.assertIn('foo13', keys)
+        self.assertIn(six.b('foo12'), keys)
+        self.assertIn(six.b('foo13'), keys)
 
-        self.assertEqual(['bar12'], self.client.get('foo12'))
-        self.assertEqual(['bar13'], self.client.get('foo13'))
+        self.assertEqual([six.b('bar12')], self.client.get('foo12'))
+        self.assertEqual([six.b('bar13')], self.client.get('foo13'))
 
         self.assertTrue(lease.revoke())
 
@@ -235,7 +236,7 @@ class TestEtcd3Gateway(base.TestCase):
         def update_etcd(v):
             self.client.put(key, v)
             out = self.client.get(key)
-            self.assertEqual([v], out)
+            self.assertEqual([six.b(v)], out)
 
         def update_key():
             # sleep to make watch can get the event
@@ -255,11 +256,11 @@ class TestEtcd3Gateway(base.TestCase):
         change_count = 0
         events_iterator, cancel = self.client.watch(key)
         for event in events_iterator:
-            self.assertEqual(event['kv']['key'], key)
-            self.assertEqual(event['kv']['value'], str(change_count))
+            self.assertEqual(event['kv']['key'], six.b(key))
+            self.assertEqual(event['kv']['value'], six.b(str(change_count)))
 
             # if cancel worked, we should not receive event 3
-            assert event['kv']['value'] != '3'
+            assert event['kv']['value'] != six.b('3')
 
             change_count += 1
             if change_count > 2:
@@ -276,7 +277,7 @@ class TestEtcd3Gateway(base.TestCase):
         def update_etcd(v):
             self.client.put(key + v, v)
             out = self.client.get(key + v)
-            self.assertEqual([v], out)
+            self.assertEqual([six.b(v)], out)
 
         def update_key():
             # sleep to make watch can get the event
@@ -296,14 +297,15 @@ class TestEtcd3Gateway(base.TestCase):
         change_count = 0
         events_iterator, cancel = self.client.watch_prefix(key)
         for event in events_iterator:
-            if not event['kv']['key'].startswith(key):
+            if not event['kv']['key'].startswith(six.b(key)):
                 continue
 
-            self.assertEqual(event['kv']['key'], '%s%s' % (key, change_count))
-            self.assertEqual(event['kv']['value'], str(change_count))
+            self.assertEqual(event['kv']['key'],
+                             six.b('%s%s' % (key, change_count)))
+            self.assertEqual(event['kv']['value'], six.b(str(change_count)))
 
             # if cancel worked, we should not receive event 3
-            assert event['kv']['value'] != '3'
+            assert event['kv']['value'] != six.b('3')
 
             change_count += 1
             if change_count > 2:
@@ -365,7 +367,7 @@ class TestEtcd3Gateway(base.TestCase):
 
         status = self.client.create(key, 'bar')
         # Verify that key is 'bar'
-        self.assertEqual(['bar'], self.client.get(key))
+        self.assertEqual([six.b('bar')], self.client.get(key))
         self.assertTrue(status)
 
     @unittest.skipUnless(
@@ -374,9 +376,9 @@ class TestEtcd3Gateway(base.TestCase):
         key = '/foo/' + str(uuid.uuid4())
         # Assign value to the key
         self.client.put(key, 'bar')
-        self.assertEqual(['bar'], self.client.get(key))
+        self.assertEqual([six.b('bar')], self.client.get(key))
 
         status = self.client.create(key, 'goo')
         # Verify that key is still 'bar'
-        self.assertEqual(['bar'], self.client.get(key))
+        self.assertEqual([six.b('bar')], self.client.get(key))
         self.assertFalse(status)

--- a/etcd3gw/utils.py
+++ b/etcd3gw/utils.py
@@ -34,7 +34,7 @@ def _decode(data):
     """Decode the base-64 encoded string
 
     :param data:
-    :return: decoded string
+    :return: decoded data
     """
     if not isinstance(data, bytes_types):
         data = six.b(str(data))


### PR DESCRIPTION
utils._decode() returns base64-decoded data. In Python 2 it is an
instance of str() while in Python 3 the returned value is an instance of
bytes(). This commit makes etcd3gw lock work and the unit tests run
correctly without the implicit convention between str and bytes in
Python 3.

Fixes: #24