### PR TITLE
Make the package reproducible

### DIFF
--- a/etcd3gw/client.py
+++ b/etcd3gw/client.py
@@ -117,13 +117,15 @@ class Etcd3Client(object):
                            json={"TTL": ttl, "ID": 0})
         return Lease(int(result['ID']), client=self)
 
-    def lock(self, id=str(uuid.uuid4()), ttl=DEFAULT_TIMEOUT):
+    def lock(self, id=None, ttl=DEFAULT_TIMEOUT):
         """Create a Lock object given an ID and timeout
 
         :param id: ID for the lock, creates a new uuid if not provided
         :param ttl: timeout
         :return: Lock object
         """
+        if id is None:
+            id = str(uuid.uuid4())
         return Lock(id, ttl=ttl, client=self)
 
     def create(self, key, value):


### PR DESCRIPTION
Whilst working on the Reproducible Builds effort [0] we noticed
that python-etcd3gw could not be built reproducibly.

This is because one of the function signatures used a non-
deterministic / random default value that was rendered by the
documentation system at build time and thus varied each time.

 [0] https://reproducible-builds.org/

Note: The original author of this patch is Chris Lamb <lamby@debian.org>