### PR TITLE
Fix exception signature

### DIFF
--- a/etcd3gw/client.py
+++ b/etcd3gw/client.py
@@ -83,7 +83,7 @@ class Etcd3Client(object):
             if resp.status_code in _EXCEPTIONS_BY_CODE:
                 raise _EXCEPTIONS_BY_CODE[resp.status_code](resp.reason)
             if resp.status_code != requests.codes['ok']:
-                raise exceptions.Etcd3Exception(resp.reason, resp.text)
+                raise exceptions.Etcd3Exception(resp.text, resp.reason)
         except requests.exceptions.Timeout as ex:
             raise exceptions.ConnectionTimeoutError(six.text_type(ex))
         except requests.exceptions.ConnectionError as ex:

--- a/etcd3gw/exceptions.py
+++ b/etcd3gw/exceptions.py
@@ -12,8 +12,8 @@
 
 
 class Etcd3Exception(Exception):
-    def __init__(self, msg, detail_text=None):
-        super(Etcd3Exception, self).__init__(msg)
+    def __init__(self, detail_text=None, *args):
+        super(Etcd3Exception, self).__init__(*args)
         self.detail_text = detail_text
 
 


### PR DESCRIPTION
I previously extended the Etcd3Exception constructor signature such
that it was no longer possible for the derived exception types to
construct with no args.  This change aims to make that possible again, while
still allowing an Etcd3Exception to be constructed with detail text as
well as the traditional "Bad Request" message.