### PR TITLE
Make API path configurable due to `v3alpha` deprecation + fix pep8

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@
 [![pypi status](https://img.shields.io/pypi/status/etcd3gw.svg)](https://pypi.python.org/pypi/etcd3gw)
 [![pypi supported versions](https://img.shields.io/pypi/pyversions/etcd3gw.svg)](https://pypi.python.org/pypi/etcd3gw)
 
-A python client for etcd3 grpc-gateway v3alpha API
+A python client for etcd3 grpc-gateway v3 API

--- a/etcd3gw/client.py
+++ b/etcd3gw/client.py
@@ -41,8 +41,9 @@ _EXCEPTIONS_BY_CODE = {
 
 class Etcd3Client(object):
     def __init__(self, host='localhost', port=2379, protocol="http",
-                 ca_cert=None, cert_key=None, cert_cert=None, timeout=None):
-        """Construct an client to talk to etcd3's grpc-gateway's /v3alpha HTTP API
+                 ca_cert=None, cert_key=None, cert_cert=None, timeout=None,
+                 api_path='/v3beta/'):
+        """Construct an client to talk to etcd3's grpc-gateway's /v3 HTTP API
 
         :param host:
         :param port:
@@ -59,9 +60,10 @@ class Etcd3Client(object):
             self.session.verify = ca_cert
         if cert_cert is not None and cert_key is not None:
             self.session.cert = (cert_cert, cert_key)
+        self.api_path = api_path
 
     def get_url(self, path):
-        """Construct a full url to the v3alpha API given a specific path
+        """Construct a full url to the v3 API given a specific path
 
         :param path:
         :return: url
@@ -69,7 +71,7 @@ class Etcd3Client(object):
         host = ('[' + self.host + ']' if (self.host.find(':') != -1)
                 else self.host)
         base_url = self.protocol + '://' + host + ':' + str(self.port)
-        return base_url + '/v3alpha/' + path.lstrip("/")
+        return base_url + self.api_path + path.lstrip("/")
 
     def post(self, *args, **kwargs):
         """helper method for HTTP POST

--- a/etcd3gw/tests/test_client.py
+++ b/etcd3gw/tests/test_client.py
@@ -22,17 +22,17 @@ class TestEtcd3Gateway(base.TestCase):
 
     def test_client_default(self):
         client = Etcd3Client()
-        self.assertEqual("http://localhost:2379/v3alpha/lease/grant",
+        self.assertEqual("http://localhost:2379/v3beta/lease/grant",
                          client.get_url("/lease/grant"))
 
     def test_client_ipv4(self):
         client = Etcd3Client(host="127.0.0.1")
-        self.assertEqual("http://127.0.0.1:2379/v3alpha/lease/grant",
+        self.assertEqual("http://127.0.0.1:2379/v3beta/lease/grant",
                          client.get_url("/lease/grant"))
 
     def test_client_ipv6(self):
         client = Etcd3Client(host="::1")
-        self.assertEqual("http://[::1]:2379/v3alpha/lease/grant",
+        self.assertEqual("http://[::1]:2379/v3beta/lease/grant",
                          client.get_url("/lease/grant"))
 
     def test_client_bad_request(self):

--- a/etcd3gw/tests/test_etcd3gw.py
+++ b/etcd3gw/tests/test_etcd3gw.py
@@ -19,6 +19,7 @@ Tests for `etcd3gw` module.
 
 import six
 import threading
+import time
 import uuid
 
 from testtools.testcase import unittest
@@ -33,6 +34,7 @@ try:
     from time import perf_counter as clock
 except ImportError:
     from time import clock
+
 
 def _is_etcd3_running():
     try:


### PR DESCRIPTION
v3alpha was removed since v3.4 etcd,
v3beta will be removed in v3.5.

Use v3beta as default for now as compatible with
both v3.3 and v3.4 versions.

Deprecation info can be found here https://github.com/etcd-io/etcd/blob/master/Documentation/dev-guide/api_grpc_gateway.md#notes

+ fix pep8 warnings.