### PR TITLE
Add lease param into create()

### DIFF
--- a/etcd3gw/client.py
+++ b/etcd3gw/client.py
@@ -133,7 +133,7 @@ class Etcd3Client(object):
             id = str(uuid.uuid4())
         return Lock(id, ttl=ttl, client=self)
 
-    def create(self, key, value):
+    def create(self, key, value, lease=None):
         """Atomically create the given key only if the key doesn't exist.
 
         This verifies that the create_revision of a key equales to 0, then
@@ -143,6 +143,7 @@ class Etcd3Client(object):
         :param key: key in etcd to create
         :param value: value of the key
         :type value: bytes or string
+        :param lease: lease to connect with, optional
         :returns: status of transaction, ``True`` if the create was
                   successful, ``False`` otherwise
         :rtype: bool
@@ -164,6 +165,8 @@ class Etcd3Client(object):
             }],
             'failure': []
         }
+        if lease:
+            txn['success'][0]['request_put']['lease'] = lease.id
         result = self.transaction(txn)
         if 'succeeded' in result:
             return result['succeeded']

--- a/etcd3gw/tests/test_etcd3gw.py
+++ b/etcd3gw/tests/test_etcd3gw.py
@@ -388,3 +388,19 @@ class TestEtcd3Gateway(base.TestCase):
         # Verify that key is still 'bar'
         self.assertEqual([six.b('bar')], self.client.get(key))
         self.assertFalse(status)
+
+    @unittest.skipUnless(
+        _is_etcd3_running(), "etcd3 is not available")
+    def test_create_with_lease_success(self):
+        key = '/foo/unique' + str(uuid.uuid4())
+        # Verify that key is empty
+        self.assertEqual([], self.client.get(key))
+        lease = self.client.lease()
+
+        status = self.client.create(key, 'bar', lease=lease)
+        # Verify that key is 'bar'
+        self.assertEqual([six.b('bar')], self.client.get(key))
+        self.assertTrue(status)
+        keys = lease.keys()
+        self.assertEqual(1, len(keys))
+        self.assertIn(six.b(key), keys)


### PR DESCRIPTION
It's needed to atomically create key and quarantee
that it has a lease and will be pruned if
client died and didn't add lease right after create().

Signed-off-by: George Melikov <mail@gmelikov.ru>