### PR TITLE
Fix for CVE-2018-18074 - bump requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@
 
 pbr>=2.0 # Apache-2.0
 urllib3>=1.15.1  # MIT
-requests>=2.10.0,!=2.12.2,!=2.13.0  # Apache-2.0
+requests>=2.20.0  # Apache-2.0
 six>=1.9.0  # MIT
 futurist>=0.11.0,!=0.15.0  # Apache-2.0


### PR DESCRIPTION
CVE-2018-18074
moderate severity
Vulnerable versions: <= 2.19.1
Patched version: 2.20.0

The Requests package through 2.19.1 before 2018-09-14 for Python sends an HTTP Authorization header to an http URI upon receiving a same-hostname https-to-http redirect, which makes it easier for remote attackers to discover credentials by sniffing the network.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>