### PR TITLE
Add mock to test dependencies

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -16,6 +16,7 @@ pifpaf>=0.10.0 # Apache-2.0
 codecov>=1.4.0
 nose>=1.3.7
 pytest
+mock>=2.0.0 # BSD
 
 # releasenotes
 reno>=1.8.0 # Apache-2.0


### PR DESCRIPTION
Unit testing uses the third party mock package, but it is not currently
declared in test-requirements.txt. Once py27 support is dropped, usage
could be switched from the third party mock package to the standard lib
unittest.mock. But until then, this explicitly declares the dependency
in the requirements.