### PR TITLE
Raise hacking checks to recent version

### DIFF
--- a/etcd3gw/utils.py
+++ b/etcd3gw/utils.py
@@ -74,6 +74,7 @@ def _try_import(import_str, default=None):
     except ImportError:
         return default
 
+
 # These may or may not exist; so carefully import them if we can...
 _eventlet = _try_import('eventlet')
 _patcher = _try_import('eventlet.patcher')

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
-hacking>=0.12.0,!=0.13.0,<0.14  # Apache-2.0
+hacking>=3.0,<3.1.0 # Apache-2.0
 
 coverage>=4.0 # Apache-2.0
 python-subunit>=0.0.18 # Apache-2.0/BSD


### PR DESCRIPTION
This raises the hacking constraint, which pulls in various newer linter
versions due to its own constraints, and fixes an issue the newer
linters identified.